### PR TITLE
Navier–Stokes smoothness order fix

### DIFF
--- a/Problems/NavierStokes/Equations.lean
+++ b/Problems/NavierStokes/Equations.lean
@@ -167,7 +167,7 @@ the regularity demanded by the Millennium statement is imposed on the half-space
 `ℝⁿ × [0,∞)`.
 -/
 def velocity_smooth_on_global_spacetime_domain {n : ℕ} (u : VelocityField n) : Prop :=
-  ContDiffOn ℝ ⊤ (fun y => u y) (global_spacetime_domain n)
+  ContDiffOn ℝ (⊤ : ℕ∞) (fun y => u y) (global_spacetime_domain n)
 
 /--
 Smoothness of a pressure field on Clay's global time domain.
@@ -175,7 +175,7 @@ Smoothness of a pressure field on Clay's global time domain.
 This is the scalar analogue of `velocity_smooth_on_global_spacetime_domain`.
 -/
 def pressure_smooth_on_global_spacetime_domain {n : ℕ} (p : PressureField n) : Prop :=
-  ContDiffOn ℝ ⊤ (fun y => p y) (global_spacetime_domain n)
+  ContDiffOn ℝ (⊤ : ℕ∞) (fun y => p y) (global_spacetime_domain n)
 
 /--
 Smoothness of a force field on Clay's global time domain.
@@ -184,7 +184,7 @@ This matches the force hypotheses in Fefferman's conditions (5) and (9), where `
 `ℝⁿ × [0,∞)` rather than on all of ambient spacetime.
 -/
 def force_smooth_on_global_spacetime_domain {n : ℕ} (f : ForceField n) : Prop :=
-  ContDiffOn ℝ ⊤ (fun y => f y) (global_spacetime_domain n)
+  ContDiffOn ℝ (⊤ : ℕ∞) (fun y => f y) (global_spacetime_domain n)
 
 /--
 A global-in-time Navier–Stokes solution on `ℝⁿ × [0,∞)`.

--- a/Problems/NavierStokes/MillenniumBoundedDomain.lean
+++ b/Problems/NavierStokes/MillenniumBoundedDomain.lean
@@ -76,7 +76,7 @@ def PeriodicForceDecay (f : ForceField 3) : Prop :=
 theorem zero_force_periodic_decay :
     PeriodicForceDecay (fun _ : Spacetime3 => (0 : Space3)) := by
   refine ⟨?_, ?_⟩
-  · change ContDiffOn ℝ ⊤ (fun _ : Spacetime3 => (0 : Space3)) (global_spacetime_domain 3)
+  · change ContDiffOn ℝ (⊤ : ℕ∞) (fun _ : Spacetime3 => (0 : Space3)) (global_spacetime_domain 3)
     fun_prop
   intro α m K
   refine ⟨1, by norm_num, ?_⟩
@@ -110,7 +110,7 @@ Fefferman's statement (B): Existence and smoothness in the periodic setting, wit
 -/
 def SmoothExistence : Prop :=
   ∀ (ν : ℝ) (ν_pos : ν > 0) (u₀ : Space3 → Space3),
-    ContDiff ℝ ⊤ u₀ →
+    ContDiff ℝ (⊤ : ℕ∞) u₀ →
     PeriodicInitial u₀ →
       ∀ hdiv : DivergenceFreeInitial u₀,
       ∃ sol : GlobalSmoothSolution (equations ν ν_pos u₀ hdiv (fun _ => 0)),
@@ -124,7 +124,7 @@ solution-side condition is periodicity (10).
 theorem SmoothExistence.iff_periodic_fields :
     SmoothExistence ↔
       ∀ (ν : ℝ) (ν_pos : ν > 0) (u₀ : Space3 → Space3),
-        ContDiff ℝ ⊤ u₀ →
+        ContDiff ℝ (⊤ : ℕ∞) u₀ →
         PeriodicInitial u₀ →
         ∀ hdiv : DivergenceFreeInitial u₀,
           ∃ sol : GlobalSmoothSolution (equations ν ν_pos u₀ hdiv (fun _ => 0)),
@@ -143,7 +143,7 @@ Fefferman's statement (D): Breakdown in the periodic setting (forcing allowed).
 def Breakdown : Prop :=
   ∀ (ν : ℝ) (ν_pos : ν > 0),
   ∃ (u₀ : Space3 → Space3) (f : ForceField 3),
-    ContDiff ℝ ⊤ u₀ ∧
+    ContDiff ℝ (⊤ : ℕ∞) u₀ ∧
     PeriodicInitial u₀ ∧
     DivergenceFreeInitial u₀ ∧
     PeriodicForce f ∧
@@ -161,7 +161,7 @@ theorem Breakdown.iff_no_periodic_solution :
     Breakdown ↔
       ∀ (ν : ℝ) (ν_pos : ν > 0),
       ∃ (u₀ : Space3 → Space3) (f : ForceField 3),
-        ContDiff ℝ ⊤ u₀ ∧
+        ContDiff ℝ (⊤ : ℕ∞) u₀ ∧
         PeriodicInitial u₀ ∧
         DivergenceFreeInitial u₀ ∧
         PeriodicForce f ∧

--- a/Problems/NavierStokes/MillenniumRDomain.lean
+++ b/Problems/NavierStokes/MillenniumRDomain.lean
@@ -42,7 +42,7 @@ We encode multi-indices as lists of coordinate directions, giving a direct coord
 derivative decay condition.
 -/
 def SmoothRapidDecayInitial (u₀ : InitialVelocity) : Prop :=
-  ContDiff ℝ ⊤ u₀ ∧
+  ContDiff ℝ (⊤ : ℕ∞) u₀ ∧
     ∀ (α : List (Fin 3)) (K : ℕ),
       ∃ C : ℝ, 0 < C ∧ ∀ x : Space3,
         ‖spatial_derivative_vector u₀ α x‖ ≤ C / (1 + ‖x‖) ^ K
@@ -78,7 +78,7 @@ def SmoothRapidDecayForce (f : SpacetimeForce) : Prop :=
 theorem zero_force_smooth_rapid_decay :
     SmoothRapidDecayForce (fun _ : Spacetime3 => (0 : Space3)) := by
   refine ⟨?_, ?_⟩
-  · change ContDiffOn ℝ ⊤ (fun _ : Spacetime3 => (0 : Space3)) (global_spacetime_domain 3)
+  · change ContDiffOn ℝ (⊤ : ℕ∞) (fun _ : Spacetime3 => (0 : Space3)) (global_spacetime_domain 3)
     fun_prop
   intro α m K
   refine ⟨1, by norm_num, ?_⟩


### PR DESCRIPTION
## Overview

"Smoothness" here is a ladder: rung `k` means "differentiable `k` times", and the top of the usual ladder is `C^∞`, differentiable forever. That's what "smooth" means in the Clay problem. Recently Mathlib added a new rung above`C^∞`: analytic.

This is a far more rigid class, where a function's values on any tiny patch already pin it down everywhere. The symbol `⊤` ("the top") used to mean `C^∞`; now it means analytic. The Navier–Stokes files still say "the top," so without anyone editing them they quietly started demanding _analytic_ fluids. This may lead some people down the wrong path (like me!)

This matters because analytic rules out exactly the flows the subject is about: you can't build an analytic "bump" that's an energetic blob in one spot and flatly zero elsewhere (`e^{-1/x²}` is the classic `C^∞`-but-not-analytic witness). 

Localized data, cut-offs, a swirl that's violent here and calm there, all `C^∞`, none analytic. And this is a statement file: the definition of the target every proof or counterexample is checked against. If it says "analytic" where it should say `C^∞`, someone might certify the wrong theorem. One coercion, `(⊤ : ℕ∞)`, puts the target back on the C^∞ rung, the actual Millennium problem.

## Issue

Mathlib's smoothness order is now `WithTop ℕ∞`, which has **two tops**:

- `(⊤ : ℕ∞)` = `∞` = **C^∞** (infinitely differentiable)
- `⊤` = `ω` = **analytic**

The Navier–Stokes files write bare `ContDiff ℝ ⊤` / `ContDiffOn ℝ ⊤`, so they demand **analytic** data and solutions — strictly stronger than the Clay problem, which asks for **C^∞**. Confirmed against the repo's own pin (Mathlib v4.31.0).

## Solution

Replace the bare top with the C^∞ top in all 10 occurrences across the 3 NS files:

```lean
ContDiff   ℝ ⊤   →   ContDiff   ℝ (⊤ : ℕ∞)
ContDiffOn ℝ ⊤   →   ContDiffOn ℝ (⊤ : ℕ∞)
```

- `Problems/NavierStokes/Equations.lean` (3)
- `Problems/NavierStokes/MillenniumRDomain.lean` (2)
- `Problems/NavierStokes/MillenniumBoundedDomain.lean` (5)

So 10 total edits.

Builds clean against pinned Mathlib (v4.31.0); no new `sorry`