### PR TITLE
Fix implication direction in Yang-Mills locality hypotheses

### DIFF
--- a/Problems/YangMills/Millennium.lean
+++ b/Problems/YangMills/Millennium.lean
@@ -1166,7 +1166,7 @@ structure ClayQuantumFieldTheoryAxioms {G : Type} [CompactSimpleGaugeGroup G]
   field_locality :
     ∀ (f g : SchwartzMap Spacetime ℝ),
       (∀ (x y : Spacetime),
-        (minkowski_metric (x - y) (x - y) < 0) → f x = 0 ∨ g y = 0) →
+        f x ≠ 0 → g y ≠ 0 → minkowski_metric (x - y) (x - y) < 0) →
       theory.field_operators f ∘L theory.field_operators g =
         theory.field_operators g ∘L theory.field_operators f
   /-- Positive-energy Hamiltonian. -/
@@ -1202,7 +1202,7 @@ structure ClayQuantumFieldTheoryAxioms {G : Type} [CompactSimpleGaugeGroup G]
   local_operator_locality :
     ∀ (p q : GaugeInvariantLocalPolynomial G) (f g : SchwartzMap Spacetime ℝ),
       (∀ (x y : Spacetime),
-        (minkowski_metric (x - y) (x - y) < 0) → f x = 0 ∨ g y = 0) →
+        f x ≠ 0 → g y ≠ 0 → minkowski_metric (x - y) (x - y) < 0) →
       (theory.local_operators.op p f) ∘L (theory.local_operators.op q g) =
         (theory.local_operators.op q g) ∘L (theory.local_operators.op p f)
   /-- Distributional conservation law for the stress-energy tensor. -/

--- a/Problems/YangMills/Quantum.lean
+++ b/Problems/YangMills/Quantum.lean
@@ -969,7 +969,7 @@ class WightmanQuantumFieldTheoryProperties (H : Type) [NormedAddCommGroup H] [In
   -- W5: Locality/causality
   locality : ∀ (f g : SchwartzMap Spacetime ℝ),
     (∀ (x y : Spacetime),
-      (minkowski_metric (x - y) (x - y) < 0) → f x = 0 ∨ g y = 0) →
+      f x ≠ 0 → g y ≠ 0 → minkowski_metric (x - y) (x - y) < 0) →
     Φ f ∘L Φ g = Φ g ∘L Φ f  -- Fields commute at spacelike separation
 
 /-!
@@ -1134,7 +1134,7 @@ structure QuantumYangMillsTheory (G : Type) [CompactSimpleGaugeGroup G] where
   local_operators_locality :
     ∀ (p q : GaugeInvariantLocalPolynomial G) (f g : SchwartzMap Spacetime ℝ),
       (∀ (x y : Spacetime),
-        (minkowski_metric (x - y) (x - y) < 0) → f x = 0 ∨ g y = 0) →
+        f x ≠ 0 → g y ≠ 0 → minkowski_metric (x - y) (x - y) < 0) →
       (local_operators.op p f) ∘L (local_operators.op q g) =
         (local_operators.op q g) ∘L (local_operators.op p f)
 


### PR DESCRIPTION
## Summary

The locality/causality axioms in the Yang–Mills formalization state the spacelike-separation hypothesis on test functions with the implication pointing the wrong way.

Current form (all four occurrences):

```lean
∀ x y, minkowski_metric (x - y) (x - y) < 0 → f x = 0 ∨ g y = 0
```

With signature `(+,-,-,-)`, `minkowski_metric (x - y) (x - y) < 0` means `x` and `y` are spacelike separated. So this hypothesis says: *whenever two points are spacelike separated, `f` and `g` cannot both be nonzero there* — i.e. **no** spacelike pair lies in `supp f × supp g`. That forces the supports to be non-spacelike separated, which is the opposite of the Wightman locality condition, and means field/local-operator commutation was being demanded for the wrong class of test-function pairs.

This PR restates it as

```lean
∀ x y, f x ≠ 0 → g y ≠ 0 → minkowski_metric (x - y) (x - y) < 0
```

so that *every* pair of points in the respective supports is spacelike separated, which is the intended hypothesis within the repository's existing pointwise-support model.

## Changes

Same one-line fix applied to all four occurrences:

- `Problems/YangMills/Quantum.lean`
  - `WightmanAxioms.locality`
  - `QuantumYangMillsTheory.local_operators_locality`
- `Problems/YangMills/Millennium.lean`
  - `ClayQuantumFieldTheoryAxioms.field_locality`
  - `ClayQuantumFieldTheoryAxioms.local_operator_locality`

The forwarding in `Millennium.lean` (`field_locality := theory.wightman.locality`, `local_operator_locality := theory.local_operators_locality`) is unchanged since both sides were updated identically.

## Testing

- `lake build` (full project) succeeds on `leanprover/lean4:v4.31.0` with the pinned Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
